### PR TITLE
Explain that Tor 0.3.5.8 is LTS

### DIFF
--- a/index.html
+++ b/index.html
@@ -88,7 +88,7 @@ http://www.templatemo.com/tm-501-neaty
                             <section id="releases" class="tm-section">
                                 <header><h2 class="tm-blue-text tm-section-title tm-margin-b-30">Releases</h2></header>
                                 <h3>Mac OS X</h3>
-                                Ricochet Refresh now has a pre-release for Mac OS X. We have included the latest version of Tor 0.3.5.8 in the pre-release.
+                                Ricochet Refresh now has a pre-release for Mac OS X. We have included Tor 0.3.5.8 in the pre-release, which is the latest long term support version.
                                 <br><br><br>
                                 <h4>Installation instructions</h4>
                                 <ul>
@@ -98,7 +98,7 @@ http://www.templatemo.com/tm-501-neaty
                                 </ul>
                                 <img src="img/drag.png" style="transform: scale(0.8)" alt="Drag the app into the folder.">
                                 <h3>Linux</h3>
-                                Ricochet Refresh now has a pre-release for Linux, tested on Ubuntu 18.04. We have included the latest version of Tor 0.3.5.8 in the pre-release.
+                                Ricochet Refresh now has a pre-release for Linux, tested on Ubuntu 18.04. We have included Tor 0.3.5.8 in the pre-release, which is the latest long term support version.
                                 <br><br><br>
                                 <h4>Installation instructions</h4>
                                 <ul>                                


### PR DESCRIPTION
Tor has several supported minor versions, the most recent patch releases are:
* stable 0.4.1.5,
* old stable 0.4.0.5,
* long term support 0.3.5.8, and
* old long term support 0.2.9.17.

Tor's list of current minor versions is:
https://trac.torproject.org/projects/tor/wiki/org/teams/NetworkTeam/CoreTorReleases#Current

Tor's patch releases are listed under "Tag":
https://gitweb.torproject.org/tor.git/